### PR TITLE
Fix fatal error when duplicate is not a string

### DIFF
--- a/src/Implementation/Formatters/UniqueItems.php
+++ b/src/Implementation/Formatters/UniqueItems.php
@@ -10,7 +10,7 @@ class UniqueItems extends Formatter
 
     public function replacements(): array
     {
-    	if (is_string($this->error->keywordArgs()['duplicate'])) {
+        if (is_string($this->error->keywordArgs()['duplicate'])) {
             return [
                 ':duplicate:' => $this->error->keywordArgs()['duplicate']
             ];

--- a/src/Implementation/Formatters/UniqueItems.php
+++ b/src/Implementation/Formatters/UniqueItems.php
@@ -9,7 +9,12 @@ class UniqueItems extends Formatter
     public const MESSAGE = "The attribute contains duplicated item: ':duplicate:'.";
 
     public function replacements(): array
-    {
+        $duplicate = $this->error->keywordArgs()['duplicate'];
+        $duplicate = json_encode($duplicate);
+        
+        return [
+            ':duplicate:' => $duplicate
+        ];
         if (is_string($this->error->keywordArgs()['duplicate'])) {
             return [
                 ':duplicate:' => $this->error->keywordArgs()['duplicate']

--- a/src/Implementation/Formatters/UniqueItems.php
+++ b/src/Implementation/Formatters/UniqueItems.php
@@ -9,22 +9,11 @@ class UniqueItems extends Formatter
     public const MESSAGE = "The attribute contains duplicated item: ':duplicate:'.";
 
     public function replacements(): array
+    {
         $duplicate = $this->error->keywordArgs()['duplicate'];
         $duplicate = json_encode($duplicate);
-        
         return [
             ':duplicate:' => $duplicate
         ];
-        if (is_string($this->error->keywordArgs()['duplicate'])) {
-            return [
-                ':duplicate:' => $this->error->keywordArgs()['duplicate']
-            ];
-        } elseif (json_encode($this->error->keywordArgs()['duplicate'])) {
-            return [
-                ':duplicate:' => json_encode($this->error->keywordArgs()['duplicate'])
-            ];
-        } else {
-            return [':duplicate:' => ''];
-        }
     }
 }

--- a/src/Implementation/Formatters/UniqueItems.php
+++ b/src/Implementation/Formatters/UniqueItems.php
@@ -10,8 +10,16 @@ class UniqueItems extends Formatter
 
     public function replacements(): array
     {
-        return [
-            ':duplicate:' => $this->error->keywordArgs()['duplicate']
-        ];
+    	if (is_string($this->error->keywordArgs()['duplicate'])) {
+            return [
+                ':duplicate:' => $this->error->keywordArgs()['duplicate']
+            ];
+        } elseif (json_encode($this->error->keywordArgs()['duplicate'])) {
+            return [
+                ':duplicate:' => json_encode($this->error->keywordArgs()['duplicate'])
+            ];
+        } else {
+            return [':duplicate:' => ''];
+        }
     }
 }


### PR DESCRIPTION
Hello,

Quick PR for a fatal error I found. When the UniqueItems Formatter is called and the duplicate is not a string (can be an object) we would get a fatal error.