### PR TITLE
PHP 8.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "opis/json-schema": "^1.0",
         "phpunit/phpunit": ">=7.1",
         "dg/bypass-finals": "^1.1",
-        "phpstan/phpstan": "^0.11.5",
-        "squizlabs/php_codesniffer": "^3.4"
+        "squizlabs/php_codesniffer": "^3.4",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "opis/json-schema": "^1.0",
-        "phpunit/phpunit": ">=7.1",
+        "phpunit/phpunit": ">=7.1 <10",
         "dg/bypass-finals": "^1.1",
         "squizlabs/php_codesniffer": "^3.4",
         "phpstan/phpstan": "^1.10"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpunit/phpunit": ">=7.1 <10",
         "dg/bypass-finals": "^1.1",
         "squizlabs/php_codesniffer": "^3.4",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": ">=0.11.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpunit/phpunit": ">=7.1 <10",
         "dg/bypass-finals": "^1.1",
         "squizlabs/php_codesniffer": "^3.4",
-        "phpstan/phpstan": ">=0.11.5"
+        "phpstan/phpstan": "^1"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,5 +2,5 @@ parameters:
     level: 4
     paths:
         - %rootDir%/../../../src
-    excludes_analyse:
+    excludePaths:
         - %rootDir%/../../../src/Implementation/LocaleResolvers/HttpLocaleResolver.php

--- a/src/Implementation/PresentedValidationError.php
+++ b/src/Implementation/PresentedValidationError.php
@@ -66,6 +66,7 @@ class PresentedValidationError implements Contracts\PresentedValidationError, \J
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/tests/MessageFormatterFactoryTest.php
+++ b/tests/MessageFormatterFactoryTest.php
@@ -9,6 +9,9 @@ use OpisErrorPresenter\Implementation\Formatters\Required;
 use OpisErrorPresenter\Implementation\MessageFormatterFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \OpisErrorPresenter\Implementation\MessageFormatterFactory
+ */
 class MessageFormatterFactoryTest extends TestCase
 {
     public function testShouldCreateMessageFormatter(): void

--- a/tests/PresentedValidationErrorFactoryTest.php
+++ b/tests/PresentedValidationErrorFactoryTest.php
@@ -7,6 +7,9 @@ use OpisErrorPresenter\Implementation\MessageFormatterFactory;
 use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \OpisErrorPresenter\Implementation\PresentedValidationErrorFactory
+ */
 class PresentedValidationErrorFactoryTest extends TestCase
 {
     private const EXPECTED_MESSAGE = 'The attribute is invalid';

--- a/tests/ValidationErrorPresenterTest.php
+++ b/tests/ValidationErrorPresenterTest.php
@@ -9,6 +9,9 @@ use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
 use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \OpisErrorPresenter\Implementation\ValidationErrorPresenter
+ */
 class ValidationErrorPresenterTest extends TestCase
 {
     public function testShouldPresentValidationErrors(): void


### PR DESCRIPTION
Greetings.

This PR is part of an effort to make the DKAN project PHP 8.1 compatible: https://github.com/GetDKAN

`m1x0n/opis-json-schema-error-presenter` is a dependency of DKAN.

The changes here are:
- Widen the PHP version matrix in Github actions to include PHP 7.1 all the way to 8.1.
- Update some Composer constraints. PHPStan ^1 and PHPUnit <10.
- Update phpstan.neon.dist because `excludes_analyse` is deprecated.
- Add `@covers` annotation to tests which are missing them. (See phpunit.xml: `beStrictAboutCoversAnnotation`)
- Finally, actually fix for PHP 8.1 compatibility by adding `#[\ReturnTypeWillChange]` annotation to `OpisErrorPresenter\Implementation\PresentedValidationError`.